### PR TITLE
windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ default-features = false
 
 [build-dependencies]
 pkg-config = "0.3.6"
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"
+winapi = "0.2"

--- a/examples/bind_process.rs
+++ b/examples/bind_process.rs
@@ -1,5 +1,7 @@
 extern crate hwloc;
 extern crate libc;
+#[cfg(target_os = "windows")] extern crate winapi;
+#[cfg(target_os = "windows")] extern crate kernel32;
 
 use hwloc::{Topology, CPUBIND_PROCESS, TopologyObject, ObjectType};
 
@@ -9,7 +11,7 @@ fn main() {
     let mut topo = Topology::new();
 
     // load the current pid through libc
-    let pid = unsafe { libc::getpid() };
+    let pid = get_pid();
 
     println!("Binding Process with PID {:?}", pid);
 
@@ -44,4 +46,14 @@ fn last_core(topo: &mut Topology) -> &TopologyObject {
     let core_depth = topo.depth_or_below_for_type(&ObjectType::Core).unwrap();
     let all_cores = topo.objects_at_depth(core_depth);
     all_cores.last().unwrap()
+}
+
+#[cfg(target_os = "windows")]
+fn get_pid() -> winapi::minwindef::DWORD {
+    unsafe { kernel32::GetCurrentProcessId() }
+}
+
+#[cfg(any(target_os="macos",target_os="linux"))]
+fn get_pid() -> libc::pid_t {
+    unsafe { libc::getpid() }
 }

--- a/examples/bind_threads.rs
+++ b/examples/bind_threads.rs
@@ -1,5 +1,7 @@
 extern crate hwloc;
 extern crate libc;
+#[cfg(target_os = "windows")] extern crate kernel32;
+#[cfg(target_os = "windows")] extern crate winapi;
 
 use hwloc::{Topology, ObjectType, CPUBIND_THREAD, CpuSet};
 use std::thread;
@@ -66,6 +68,12 @@ fn cpuset_for_core(topology: &Topology, idx: usize) -> CpuSet {
 
 /// Helper method to get the thread id through libc, with current rust stable (1.5.0) its not
 /// possible otherwise I think.
+#[cfg(any(target_os="macos",target_os="linux"))]
 fn get_thread_id() -> libc::pthread_t {
     unsafe { libc::pthread_self() }
+}
+
+#[cfg(target_os = "windows")]
+fn get_thread_id() -> winapi::winnt::HANDLE {
+    unsafe { kernel32::GetCurrentThread() }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,5 @@
-use libc::{c_int, c_uint, c_ulonglong, c_char, pid_t, pthread_t};
+use libc::{c_int, c_uint, c_ulonglong, c_char};
+use {pid_t, pthread_t};
 use num::{ToPrimitive, FromPrimitive};
 use topology_object::TopologyObject;
 use bitmap::IntHwlocBitmap;
@@ -172,7 +173,122 @@ impl FromPrimitive for TopologyFlag {
     }
 }
 
+#[cfg(target_os = "windows")]
+#[link(name = "libhwloc")]
+extern "C" {
 
+    // === Topology Creation and Destruction ===
+
+    pub fn hwloc_topology_init(topology: *mut *mut HwlocTopology) -> c_int;
+    pub fn hwloc_topology_load(topology: *mut HwlocTopology) -> c_int;
+    pub fn hwloc_topology_destroy(topology: *mut HwlocTopology);
+
+    // === Topology Detection Configuration and Query ===
+
+    pub fn hwloc_topology_set_flags(topology: *mut HwlocTopology, flags: c_ulonglong) -> c_int;
+    pub fn hwloc_topology_get_flags(topology: *mut HwlocTopology) -> c_ulonglong;
+    pub fn hwloc_topology_get_support(topology: *mut HwlocTopology) -> *const TopologySupport;
+
+    // === Object levels, depths and types ===
+
+    pub fn hwloc_topology_get_depth(topology: *mut HwlocTopology) -> c_uint;
+    pub fn hwloc_get_type_depth(topology: *mut HwlocTopology, object_type: ObjectType) -> c_int;
+    pub fn hwloc_get_depth_type(topology: *mut HwlocTopology, depth: c_uint) -> ObjectType;
+    pub fn hwloc_get_nbobjs_by_depth(topology: *mut HwlocTopology, depth: c_uint) -> c_uint;
+
+
+    pub fn hwloc_get_obj_by_depth(topology: *mut HwlocTopology,
+                                  depth: c_uint,
+                                  idx: c_uint)
+                                  -> *mut TopologyObject;
+
+    // === CPU Binding ===
+    pub fn hwloc_set_cpubind(topology: *mut HwlocTopology,
+                             set: *const IntHwlocBitmap,
+                             flags: c_int)
+                             -> c_int;
+    pub fn hwloc_get_cpubind(topology: *mut HwlocTopology,
+                             set: *mut IntHwlocBitmap,
+                             flags: c_int)
+                             -> c_int;
+    pub fn hwloc_get_last_cpu_location(topology: *mut HwlocTopology,
+                                       set: *mut IntHwlocBitmap,
+                                       flags: c_int)
+                                       -> c_int;
+    pub fn hwloc_get_proc_last_cpu_location(topology: *mut HwlocTopology,
+                                            pid: pid_t,
+                                            set: *mut IntHwlocBitmap,
+                                            flags: c_int)
+                                            -> c_int;
+    pub fn hwloc_set_proc_cpubind(topology: *mut HwlocTopology,
+                                  pid: pid_t,
+                                  set: *const IntHwlocBitmap,
+                                  flags: c_int)
+                                  -> c_int;
+    pub fn hwloc_get_proc_cpubind(topology: *mut HwlocTopology,
+                                  pid: pid_t,
+                                  set: *mut IntHwlocBitmap,
+                                  flags: c_int)
+                                  -> c_int;
+    pub fn hwloc_set_thread_cpubind(topology: *mut HwlocTopology,
+                                    thread: pthread_t,
+                                    set: *const IntHwlocBitmap,
+                                    flags: c_int)
+                                    -> c_int;
+    pub fn hwloc_get_thread_cpubind(topology: *mut HwlocTopology,
+                                    pid: pthread_t,
+                                    set: *mut IntHwlocBitmap,
+                                    flags: c_int)
+                                    -> c_int;
+
+    // === Memory Binding ===
+
+
+    // === Bitmap Methods ===
+    pub fn hwloc_bitmap_alloc() -> *mut IntHwlocBitmap;
+    pub fn hwloc_bitmap_alloc_full() -> *mut IntHwlocBitmap;
+    pub fn hwloc_bitmap_free(bitmap: *mut IntHwlocBitmap);
+    pub fn hwloc_bitmap_list_asprintf(strp: *mut *mut c_char,
+                                      bitmap: *const IntHwlocBitmap)
+                                      -> c_int;
+    pub fn hwloc_bitmap_set(bitmap: *mut IntHwlocBitmap, id: c_uint);
+    pub fn hwloc_bitmap_set_range(bitmap: *mut IntHwlocBitmap, begin: c_uint, end: c_int);
+    pub fn hwloc_bitmap_clr(bitmap: *mut IntHwlocBitmap, id: c_uint);
+    pub fn hwloc_bitmap_clr_range(bitmap: *mut IntHwlocBitmap, begin: c_uint, end: c_int);
+    pub fn hwloc_bitmap_weight(bitmap: *const IntHwlocBitmap) -> c_int;
+    pub fn hwloc_bitmap_zero(bitmap: *mut IntHwlocBitmap);
+    pub fn hwloc_bitmap_iszero(bitmap: *const IntHwlocBitmap) -> c_int;
+    pub fn hwloc_bitmap_isset(bitmap: *const IntHwlocBitmap, id: c_uint) -> c_int;
+    pub fn hwloc_bitmap_singlify(bitmap: *mut IntHwlocBitmap);
+    pub fn hwloc_bitmap_not(result: *mut IntHwlocBitmap, bitmap: *const IntHwlocBitmap);
+    pub fn hwloc_bitmap_first(bitmap: *const IntHwlocBitmap) -> c_int;
+    pub fn hwloc_bitmap_last(bitmap: *const IntHwlocBitmap) -> c_int;
+    pub fn hwloc_bitmap_dup(src: *const IntHwlocBitmap) -> *mut IntHwlocBitmap;
+    pub fn hwloc_bitmap_compare(left: *const IntHwlocBitmap,
+                                right: *const IntHwlocBitmap)
+                                -> c_int;
+    pub fn hwloc_bitmap_isequal(left: *const IntHwlocBitmap,
+                                right: *const IntHwlocBitmap)
+                                -> c_int;
+    pub fn hwloc_bitmap_isfull(bitmap: *const IntHwlocBitmap) -> c_int;
+    pub fn hwloc_bitmap_next(bitmap: *const IntHwlocBitmap, prev: c_int) -> c_int;
+
+    pub fn hwloc_obj_type_snprintf(into: *mut c_char,
+                                   size: c_int,
+                                   object: *const TopologyObject,
+                                   verbose: bool)
+                                   -> c_int;
+    pub fn hwloc_obj_attr_snprintf(into: *mut c_char,
+                                   size: c_int,
+                                   object: *const TopologyObject,
+                                   separator: *const c_char,
+                                   verbose: bool)
+                                   -> c_int;
+
+    pub fn hwloc_compare_types(type1: ObjectType, type2: ObjectType) -> c_int;
+}
+
+#[cfg(any(target_os="macos",target_os="linux"))]
 #[link(name = "hwloc")]
 extern "C" {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ extern crate bitflags;
 extern crate errno;
 extern crate libc;
 extern crate num;
+#[cfg(target_os = "windows")]   extern crate winapi;
 
 mod ffi;
 mod topology_object;
@@ -97,12 +98,16 @@ pub use topology_object::{TopologyObject, TopologyObjectMemory};
 
 use num::{ToPrimitive, FromPrimitive};
 use errno::errno;
-use libc::{pthread_t, pid_t};
 
 pub struct Topology {
     topo: *mut ffi::HwlocTopology,
     support: *const TopologySupport,
 }
+
+#[allow(non_camel_case_types)] #[cfg(target_os = "windows")]                    pub type pthread_t  = winapi::winnt::HANDLE;
+#[allow(non_camel_case_types)] #[cfg(target_os = "windows")]                    pub type pid_t      = winapi::minwindef::DWORD;
+#[allow(non_camel_case_types)] #[cfg(any(target_os="macos",target_os="linux"))] pub type pthread_t  = libc::pthread_t;
+#[allow(non_camel_case_types)] #[cfg(any(target_os="macos",target_os="linux"))] pub type pid_t      = libc::pid_t;
 
 unsafe impl Send for Topology {}
 unsafe impl Sync for Topology {}


### PR DESCRIPTION
Title says it all, i guess!
closes #16.

All tests are green on Ubuntu and Windows10 (rustc 1.13), and i have tested pinning tasks to cpus and it works fine.

However you should update your readme, as on windows you have to add hwloc's /bin folder to the `PATH` and the /lib folder to the `LIB` environment variable.