### PR TITLE
Make travis and appveyor run (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-sudo: false
+sudo: required
 os:
   - osx
   - linux
@@ -21,7 +21,8 @@ addons:
     packages:
       - hwloc
       - libhwloc-dev
+      - ca-certificates
 install:
-  - wget http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.1.tar.gz
-  - tar -xzvf hwloc-1.11.1.tar.gz
-  - cd hwloc-1.11.1  && ./configure && make && sudo make install
+  - wget --no-check-certificate https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.5.tar.gz
+  - tar -xzvf hwloc-1.11.5.tar.gz
+  - cd hwloc-1.11.5  && ./configure && make && sudo make install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+environment:
+  RUST_TEST_THREADS: 1
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+    RUST_CHANNEL: 1.11.0
+    VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
+  - TARGET: x86_64-pc-windows-msvc
+    RUST_CHANNEL: beta
+    VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
+  - TARGET: x86_64-pc-windows-msvc
+    RUST_CHANNEL: nightly
+    VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
+install:
+  - ps: mkdir C:/dl
+  - curl -o "C:/dl/hwloc-win64-build-1.11.5.zip" "https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.5.zip"
+  - ps: Add-Type -AssemblyName system.io.compression.filesystem
+  - ps: "[io.compression.zipfile]::ExtractToDirectory(\"C:/dl/hwloc-win64-build-1.11.5.zip\", \"C:/dl/hwloc-win64-build-1.11.5\")"
+  - ps: $env:Path += ";C:\dl\hwloc-win64-build-1.11.5\bin"
+  - ps: $env:Lib += ";C:\dl\hwloc-win64-build-1.11.5\lib"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_CHANNEL}-${env:TARGET}.exe"
+  - rust-%RUST_CHANNEL%-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - CALL "%VCVARS%"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - rustc -V
+  - cargo -V
+build: false
+test_script:
+  - cargo test --verbose


### PR DESCRIPTION
The CI build[1] on linux fails with an error due to subject alternative name not matching the host name [www.open-mpi.org](https://www.open-mpi.org). This might be due to [2]. I disabled certificate checking in an effort to fix the build and help with #3.

appveyor.yml added to help with #17.

[1] https://travis-ci.org/daschl/hwloc-rs/jobs/179941437
[2] https://bugs.launchpad.net/ubuntu/+source/wget/+bug/1580700