### PR TITLE
 libc and freebsd fixes

### DIFF
--- a/examples/bind_process.rs
+++ b/examples/bind_process.rs
@@ -13,7 +13,7 @@ fn main() {
     let mut topo = Topology::new();
 
     // load the current pid through libc
-    let pid = get_pid();
+    let pid = unsafe { libc::getpid() };
 
     println!("Binding Process with PID {:?}", pid);
 
@@ -24,21 +24,26 @@ fn main() {
     cpuset.singlify();
 
     println!("Before Bind: {:?}",
-             topo.get_cpubind_for_process(pid, CPUBIND_PROCESS).unwrap());
+             topo.get_cpubind_for_process(pid, CPUBIND_PROCESS)
+                 .unwrap());
 
     // Last CPU Location for this PID
     println!("Last Known CPU Location: {:?}",
-             topo.get_cpu_location_for_process(pid, CPUBIND_PROCESS).unwrap());
+             topo.get_cpu_location_for_process(pid, CPUBIND_PROCESS)
+                 .unwrap());
 
     // Bind to one core.
-    topo.set_cpubind_for_process(pid, cpuset, CPUBIND_PROCESS).unwrap();
+    topo.set_cpubind_for_process(pid, cpuset, CPUBIND_PROCESS)
+        .unwrap();
 
     println!("After Bind: {:?}",
-             topo.get_cpubind_for_process(pid, CPUBIND_PROCESS).unwrap());
+             topo.get_cpubind_for_process(pid, CPUBIND_PROCESS)
+                 .unwrap());
 
     // Last CPU Location for this PID
     println!("Last Known CPU Location: {:?}",
-             topo.get_cpu_location_for_process(pid, CPUBIND_PROCESS).unwrap());
+             topo.get_cpu_location_for_process(pid, CPUBIND_PROCESS)
+                 .unwrap());
 }
 
 /// Find the last core

--- a/examples/bind_threads.rs
+++ b/examples/bind_threads.rs
@@ -26,7 +26,10 @@ fn main() {
     let num_cores = {
         let topo_rc = topo.clone();
         let topo_locked = topo_rc.lock().unwrap();
-        (*topo_locked).objects_with_type(&ObjectType::Core).unwrap().len()
+        (*topo_locked)
+            .objects_with_type(&ObjectType::Core)
+            .unwrap()
+            .len()
     };
     println!("Found {} cores.", num_cores);
 
@@ -36,7 +39,8 @@ fn main() {
             let child_topo = topo.clone();
             thread::spawn(move || {
                 // Get the current thread id and lock the topology to use.
-                let tid = get_thread_id();
+                let tid = unsafe { libc::pthread_self() as usize };
+
                 let mut locked_topo = child_topo.lock().unwrap();
 
                 // Thread binding before explicit set.
@@ -46,7 +50,9 @@ fn main() {
                 let bind_to = cpuset_for_core(&*locked_topo, i);
 
                 // Set the binding.
-                locked_topo.set_cpubind_for_thread(tid, bind_to, CPUBIND_THREAD).unwrap();
+                locked_topo
+                    .set_cpubind_for_thread(tid, bind_to, CPUBIND_THREAD)
+                    .unwrap();
 
                 // Thread binding after explicit set.
                 let after = locked_topo.get_cpubind_for_thread(tid, CPUBIND_THREAD);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,5 +1,4 @@
-use libc::{c_int, c_uint, c_ulonglong, c_char};
-use {pid_t, pthread_t};
+use libc::{c_int, c_uint, c_ulonglong, c_char, pid_t, pthread_t};
 use num::{ToPrimitive, FromPrimitive};
 use topology_object::TopologyObject;
 use bitmap::IntHwlocBitmap;
@@ -288,7 +287,7 @@ extern "C" {
     pub fn hwloc_compare_types(type1: ObjectType, type2: ObjectType) -> c_int;
 }
 
-#[cfg(any(target_os="macos",target_os="linux"))]
+#[cfg(not(target_os = "windows"))]
 #[link(name = "hwloc")]
 extern "C" {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,10 @@ pub type pthread_t = winapi::winnt::HANDLE;
 #[cfg(target_os = "windows")]
 pub type pid_t = winapi::minwindef::DWORD;
 #[allow(non_camel_case_types)]
-#[cfg(any(target_os="macos",target_os="linux"))]
+#[cfg(not(target_os = "windows"))]
 pub type pthread_t = libc::pthread_t;
 #[allow(non_camel_case_types)]
-#[cfg(any(target_os="macos",target_os="linux"))]
+#[cfg(not(target_os = "windows"))]
 pub type pid_t = libc::pid_t;
 
 unsafe impl Send for Topology {}
@@ -173,7 +173,8 @@ impl Topology {
     pub fn with_flags(flags: Vec<TopologyFlag>) -> Topology {
         let mut topo: *mut ffi::HwlocTopology = std::ptr::null_mut();
 
-        let final_flag = flags.iter()
+        let final_flag = flags
+            .iter()
             .map(|f| f.to_u64().unwrap())
             .fold(0, |out, current| out | current);
 
@@ -677,6 +678,15 @@ mod tests {
     #[test]
     #[cfg(target_os="linux")]
     fn should_support_cpu_binding_on_linux() {
+        let topo = Topology::new();
+
+        assert!(topo.support().cpu().set_current_process());
+        assert!(topo.support().cpu().set_current_thread());
+    }
+
+    #[test]
+    #[cfg(target_os="freebsd")]
+    fn should_support_cpu_binding_on_freebsd() {
         let topo = Topology::new();
 
         assert!(topo.support().cpu().set_current_process());


### PR DESCRIPTION
Replace target_os="macos,linux" with !windows to include the *nixes. Add test for FreeBSD. Fix libc calls to get pid and tid.

rustfmt also did some reformatting automatically.