### PR TITLE
the Display implementation for Topology seems to have problems

### DIFF
--- a/src/topology_object.rs
+++ b/src/topology_object.rs
@@ -1,5 +1,5 @@
 use libc::{c_int, c_uint, c_ulonglong, c_char, c_void, c_float, c_ushort, c_uchar};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fmt;
 
 use ffi::ObjectType;
@@ -275,8 +275,8 @@ impl fmt::Display for TopologyObject {
 
             write!(f,
                    "{} ({})",
-                   CString::from_raw(buf_type.as_mut_ptr()).to_str().unwrap(),
-                   CString::from_raw(buf_attr.as_mut_ptr()).to_str().unwrap())
+                   CStr::from_ptr(buf_type.as_ptr()).to_str().unwrap(),
+                   CStr::from_ptr(buf_attr.as_ptr()).to_str().unwrap())
         }
     }
 }

--- a/src/topology_object.rs
+++ b/src/topology_object.rs
@@ -262,18 +262,16 @@ impl fmt::Display for TopologyObject {
 		let mut buf_attr = [0; 2048];
 
 
-        let separator = CString::new("  ").unwrap();
-        let separator_ptr = separator.into_raw();
+		let separator = b"  \0".as_ptr() as * const c_char;
 
         unsafe {
             ffi::hwloc_obj_type_snprintf(buf_type.as_mut_ptr(), buf_type.len() as c_int, &*self as *const TopologyObject, false);
             ffi::hwloc_obj_attr_snprintf(buf_attr.as_mut_ptr(),
                                          buf_attr.len() as c_int,
                                          &*self as *const TopologyObject,
-                                         separator_ptr,
+                                         separator,
                                          false);
 
-            CString::from_raw(separator_ptr);
 
             write!(f,
                    "{} ({})",

--- a/src/topology_object.rs
+++ b/src/topology_object.rs
@@ -258,19 +258,17 @@ impl TopologyObject {
 
 impl fmt::Display for TopologyObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let type_str = CString::new("").unwrap();
-        let type_str_ptr = type_str.into_raw();
+		let mut buf_type = [0; 64];
+		let mut buf_attr = [0; 2048];
 
-        let attr_str = CString::new("").unwrap();
-        let attr_str_ptr = attr_str.into_raw();
 
         let separator = CString::new("  ").unwrap();
         let separator_ptr = separator.into_raw();
 
         unsafe {
-            ffi::hwloc_obj_type_snprintf(type_str_ptr, 64, &*self as *const TopologyObject, false);
-            ffi::hwloc_obj_attr_snprintf(attr_str_ptr,
-                                         2048,
+            ffi::hwloc_obj_type_snprintf(buf_type.as_mut_ptr(), buf_type.len() as c_int, &*self as *const TopologyObject, false);
+            ffi::hwloc_obj_attr_snprintf(buf_attr.as_mut_ptr(),
+                                         buf_attr.len() as c_int,
                                          &*self as *const TopologyObject,
                                          separator_ptr,
                                          false);
@@ -279,8 +277,8 @@ impl fmt::Display for TopologyObject {
 
             write!(f,
                    "{} ({})",
-                   CString::from_raw(type_str_ptr).to_str().unwrap(),
-                   CString::from_raw(attr_str_ptr).to_str().unwrap())
+                   CString::from_raw(buf_type.as_mut_ptr()).to_str().unwrap(),
+                   CString::from_raw(buf_attr.as_mut_ptr()).to_str().unwrap())
         }
     }
 }


### PR DESCRIPTION
I just double checked the documentation for those `*_snprintf` functions. Buffers have to be allocated before calling it, so an empty CString is not appropriate.
And also those allocations can be avoided to make it faster to Display.